### PR TITLE
[TH2-1150] Add message router for message group batches

### DIFF
--- a/.github/workflows/dev-java-publish-bintray.yml
+++ b/.github/workflows/dev-java-publish-bintray.yml
@@ -1,0 +1,39 @@
+name: Dev build and publish Java distributions to Bintray
+
+on:
+  push:
+   branches-ignore:
+   - master
+   - version-*
+#     paths:
+#     - gradle.properties
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+# Prepare custom build version
+      - name: Get branch name
+        id: branch
+        run: echo ::set-output name=branch_name::${GITHUB_REF#refs/*/}
+      - name: Get release_version
+        id: ver
+        uses: christian-draeger/read-properties@1.0.1
+        with:
+          path: gradle.properties
+          property: release_version
+      - name: Build custom release version
+        id: release_ver
+        run: echo ::set-output name=value::"${{ steps.ver.outputs.value }}-${{ steps.branch.outputs.branch_name }}-${{ github.run_id }}"
+      - name: Show custom release version
+        run: echo ${{ steps.release_ver.outputs.value }}
+# Build and publish package
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Build with Gradle
+        run: ./gradlew clean build bintrayUpload -Pbintray_user=${{ secrets.BINTRAY_USER }} -Pbintray_key=${{ secrets.BINTRAY_KEY }} -Prelease_version=${{ steps.release_ver.outputs.value }}
+        # run: ./gradlew clean build -Pbintray_user=${{ secrets.BINTRAY_USER }} -Pbintray_key=${{ secrets.BINTRAY_KEY }} -Prelease_version=${{ steps.release_ver.outputs.value }}

--- a/.github/workflows/java-publish-bintray.yml
+++ b/.github/workflows/java-publish-bintray.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - version-*
 #     paths:
 #     - gradle.properties
 
@@ -13,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: '11'

--- a/build.gradle
+++ b/build.gradle
@@ -127,9 +127,9 @@ test {
 }
 
 dependencies {
-    api platform('com.exactpro.th2:bom:2.3.+')
+    api platform('com.exactpro.th2:bom:2.10.1')
     api 'com.exactpro.th2:cradle-core'
-    api 'com.exactpro.th2:grpc-common'
+    api 'com.exactpro.th2:grpc-common:3.0.0'
 
     implementation 'com.google.protobuf:protobuf-java-util'
     implementation 'com.exactpro.th2:grpc-service-generator'
@@ -162,6 +162,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
 
     implementation 'com.fasterxml.uuid:java-uuid-generator:4.0.1'
+
+    implementation 'io.github.microutils:kotlin-logging:1.7.9'
 
     implementation "org.slf4j:slf4j-log4j12"
     implementation "org.slf4j:slf4j-api"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-release_version=2.6.0
+release_version=3.0.0
 
 bintray_user=
 bintray_key=

--- a/src/main/java/com/exactpro/th2/common/schema/event/EventBatchQueue.java
+++ b/src/main/java/com/exactpro/th2/common/schema/event/EventBatchQueue.java
@@ -31,17 +31,14 @@ public class EventBatchQueue extends AbstractRabbitQueue<EventBatch> {
     @Override
     protected MessageSender<EventBatch> createSender(@NotNull ConnectionManager connectionManager, @NotNull QueueConfiguration queueConfiguration) {
         EventBatchSender eventBatchSender = new EventBatchSender();
-        eventBatchSender.init(connectionManager, queueConfiguration.getExchange(), queueConfiguration.getName());
+        eventBatchSender.init(connectionManager, queueConfiguration.getExchange(), queueConfiguration.getRoutingKey());
         return eventBatchSender;
     }
 
     @Override
     protected MessageSubscriber<EventBatch> createSubscriber(@NotNull ConnectionManager connectionManager, @NotNull QueueConfiguration queueConfiguration) {
         EventBatchSubscriber eventBatchSubscriber = new EventBatchSubscriber();
-        var subscribeTarget = SubscribeTarget.builder()
-                .routingKey(queueConfiguration.getName())
-                .queue(queueConfiguration.getQueue())
-                .build();
+        var subscribeTarget = new SubscribeTarget(queueConfiguration.getQueue(), queueConfiguration.getRoutingKey());
         eventBatchSubscriber.init(connectionManager, queueConfiguration.getExchange(), subscribeTarget);
         return eventBatchSubscriber;
     }

--- a/src/main/java/com/exactpro/th2/common/schema/event/EventBatchSubscriber.java
+++ b/src/main/java/com/exactpro/th2/common/schema/event/EventBatchSubscriber.java
@@ -16,11 +16,13 @@
 
 package com.exactpro.th2.common.schema.event;
 
+import java.util.List;
+
 import org.jetbrains.annotations.Nullable;
 
 import com.exactpro.th2.common.grpc.EventBatch;
+import com.exactpro.th2.common.schema.message.MessageRouterUtils;
 import com.exactpro.th2.common.schema.message.impl.rabbitmq.AbstractRabbitSubscriber;
-import com.google.protobuf.TextFormat;
 
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
@@ -52,13 +54,13 @@ public class EventBatchSubscriber extends AbstractRabbitSubscriber<EventBatch> {
     }
 
     @Override
-    protected EventBatch valueFromBytes(byte[] bytes) throws Exception {
-        return EventBatch.parseFrom(bytes);
+    protected List<EventBatch> valueFromBytes(byte[] bytes) throws Exception {
+        return List.of(EventBatch.parseFrom(bytes));
     }
 
     @Override
     protected String toShortDebugString(EventBatch value) {
-        return TextFormat.shortDebugString(value);
+        return MessageRouterUtils.toJson(value);
     }
 
     @Nullable

--- a/src/main/java/com/exactpro/th2/common/schema/factory/AbstractCommonFactory.java
+++ b/src/main/java/com/exactpro/th2/common/schema/factory/AbstractCommonFactory.java
@@ -52,6 +52,7 @@ import com.exactpro.cradle.cassandra.connection.CassandraConnectionSettings;
 import com.exactpro.cradle.utils.CradleStorageException;
 import com.exactpro.th2.common.grpc.EventBatch;
 import com.exactpro.th2.common.grpc.MessageBatch;
+import com.exactpro.th2.common.grpc.MessageGroupBatch;
 import com.exactpro.th2.common.grpc.RawMessageBatch;
 import com.exactpro.th2.common.metrics.CommonMetrics;
 import com.exactpro.th2.common.metrics.PrometheusConfiguration;
@@ -66,6 +67,7 @@ import com.exactpro.th2.common.schema.message.MessageRouter;
 import com.exactpro.th2.common.schema.message.configuration.MessageRouterConfiguration;
 import com.exactpro.th2.common.schema.message.impl.rabbitmq.configuration.RabbitMQConfiguration;
 import com.exactpro.th2.common.schema.message.impl.rabbitmq.connection.ConnectionManager;
+import com.exactpro.th2.common.schema.message.impl.rabbitmq.group.RabbitMessageGroupBatchRouter;
 import com.exactpro.th2.common.schema.message.impl.rabbitmq.parsed.RabbitParsedBatchRouter;
 import com.exactpro.th2.common.schema.message.impl.rabbitmq.raw.RabbitRawBatchRouter;
 import com.exactpro.th2.common.schema.strategy.route.RoutingStrategy;
@@ -99,11 +101,13 @@ public abstract class AbstractCommonFactory implements AutoCloseable {
     private final GrpcRouterConfiguration grpcRouterConfiguration = loadGrpcRouterConfiguration();
     private final Class<? extends MessageRouter<MessageBatch>> messageRouterParsedBatchClass;
     private final Class<? extends MessageRouter<RawMessageBatch>> messageRouterRawBatchClass;
+    private final Class<? extends MessageRouter<MessageGroupBatch>> messageRouterMessageGroupBatchClass;
     private final Class<? extends MessageRouter<EventBatch>> eventBatchRouterClass;
     private final Class<? extends GrpcRouter> grpcRouterClass;
     private final AtomicReference<ConnectionManager> rabbitMqConnectionManager = new AtomicReference<>();
     private final AtomicReference<MessageRouter<MessageBatch>> messageRouterParsedBatch = new AtomicReference<>();
     private final AtomicReference<MessageRouter<RawMessageBatch>> messageRouterRawBatch = new AtomicReference<>();
+    private final AtomicReference<MessageRouter<MessageGroupBatch>> messageRouterMessageGroupBatch = new AtomicReference<>();
     private final AtomicReference<MessageRouter<EventBatch>> eventBatchRouter = new AtomicReference<>();
     private final AtomicReference<GrpcRouter> grpcRouter = new AtomicReference<>();
     private final AtomicReference<HTTPServer> prometheusExporter = new AtomicReference<>();
@@ -118,7 +122,7 @@ public abstract class AbstractCommonFactory implements AutoCloseable {
      * Create factory with default implementation schema classes
      */
     public AbstractCommonFactory() {
-        this(RabbitParsedBatchRouter.class, RabbitRawBatchRouter.class, EventBatchRouter.class, DefaultGrpcRouter.class);
+        this(RabbitParsedBatchRouter.class, RabbitRawBatchRouter.class, RabbitMessageGroupBatchRouter.class, EventBatchRouter.class, DefaultGrpcRouter.class);
     }
 
     /**
@@ -130,14 +134,17 @@ public abstract class AbstractCommonFactory implements AutoCloseable {
      * @param grpcRouterClass               Class for {@link GrpcRouter}
      */
     public AbstractCommonFactory(@NotNull Class<? extends MessageRouter<MessageBatch>> messageRouterParsedBatchClass,
-                                 @NotNull Class<? extends MessageRouter<RawMessageBatch>> messageRouterRawBatchClass,
-                                 @NotNull Class<? extends MessageRouter<EventBatch>> eventBatchRouterClass,
-                                 @NotNull Class<? extends GrpcRouter> grpcRouterClass) {
+            @NotNull Class<? extends MessageRouter<RawMessageBatch>> messageRouterRawBatchClass,
+            @NotNull Class<? extends MessageRouter<MessageGroupBatch>> messageRouterMessageGroupBatchClass,
+            @NotNull Class<? extends MessageRouter<EventBatch>> eventBatchRouterClass,
+            @NotNull Class<? extends GrpcRouter> grpcRouterClass) {
         this.messageRouterParsedBatchClass = messageRouterParsedBatchClass;
         this.messageRouterRawBatchClass = messageRouterRawBatchClass;
+        this.messageRouterMessageGroupBatchClass = messageRouterMessageGroupBatchClass;
         this.eventBatchRouterClass = eventBatchRouterClass;
         this.grpcRouterClass = grpcRouterClass;
     }
+
     public void start() {
         DefaultExports.initialize();
         PrometheusConfiguration prometheusConfiguration = loadPrometheusConfiguration();
@@ -189,6 +196,26 @@ public abstract class AbstractCommonFactory implements AutoCloseable {
                     router.init(getRabbitMqConnectionManager(), getMessageRouterConfiguration());
                 } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                     throw new CommonFactoryException("Can not create raw message router", e);
+                }
+            }
+
+            return router;
+        });
+    }
+
+    /**
+     * @return Initialized {@link MessageRouter} which works with {@link MessageGroupBatch}
+     * @throws CommonFactoryException if can not call default constructor from class
+     * @throws IllegalStateException  if can not read configuration
+     */
+    public MessageRouter<MessageGroupBatch> getMessageRouterMessageGroupBatch() {
+        return messageRouterMessageGroupBatch.updateAndGet(router -> {
+            if (router == null) {
+                try {
+                    router = messageRouterMessageGroupBatchClass.getConstructor().newInstance();
+                    router.init(getRabbitMqConnectionManager(), getMessageRouterConfiguration());
+                } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                    throw new CommonFactoryException("Can not create group message router", e);
                 }
             }
 

--- a/src/main/java/com/exactpro/th2/common/schema/factory/CommonFactory.java
+++ b/src/main/java/com/exactpro/th2/common/schema/factory/CommonFactory.java
@@ -27,6 +27,7 @@ import org.apache.commons.cli.ParseException;
 
 import com.exactpro.th2.common.grpc.EventBatch;
 import com.exactpro.th2.common.grpc.MessageBatch;
+import com.exactpro.th2.common.grpc.MessageGroupBatch;
 import com.exactpro.th2.common.grpc.RawMessageBatch;
 import com.exactpro.th2.common.schema.cradle.CradleConfiguration;
 import com.exactpro.th2.common.schema.grpc.router.GrpcRouter;
@@ -55,11 +56,12 @@ public class CommonFactory extends AbstractCommonFactory {
     private final Path dictionariesDir;
 
     public CommonFactory(Class<? extends MessageRouter<MessageBatch>> messageRouterParsedBatchClass,
-                         Class<? extends MessageRouter<RawMessageBatch>> messageRouterRawBatchClass,
-                         Class<? extends MessageRouter<EventBatch>> eventBatchRouterClass,
-                         Class<? extends GrpcRouter> grpcRouterClass,
-                         Path rabbitMQ, Path routerMQ, Path routerGRPC, Path cradle, Path custom, Path prometheus, Path dictionariesDir) {
-        super(messageRouterParsedBatchClass, messageRouterRawBatchClass, eventBatchRouterClass, grpcRouterClass);
+            Class<? extends MessageRouter<RawMessageBatch>> messageRouterRawBatchClass,
+            Class<? extends MessageRouter<MessageGroupBatch>> messageRouterMessageGroupBatchClass,
+            Class<? extends MessageRouter<EventBatch>> eventBatchRouterClass,
+            Class<? extends GrpcRouter> grpcRouterClass,
+            Path rabbitMQ, Path routerMQ, Path routerGRPC, Path cradle, Path custom, Path prometheus, Path dictionariesDir) {
+        super(messageRouterParsedBatchClass, messageRouterRawBatchClass, messageRouterMessageGroupBatchClass, eventBatchRouterClass, grpcRouterClass);
         this.rabbitMQ = rabbitMQ;
         this.routerMQ = routerMQ;
         this.routerGRPC = routerGRPC;
@@ -82,10 +84,11 @@ public class CommonFactory extends AbstractCommonFactory {
     }
 
     public CommonFactory(Class<? extends MessageRouter<MessageBatch>> messageRouterParsedBatchClass,
-                         Class<? extends MessageRouter<RawMessageBatch>> messageRouterRawBatchClass,
-                         Class<? extends MessageRouter<EventBatch>> eventBatchRouterClass,
-                         Class<? extends GrpcRouter> grpcRouterClass) {
-        this(messageRouterParsedBatchClass, messageRouterRawBatchClass, eventBatchRouterClass, grpcRouterClass,
+            Class<? extends MessageRouter<RawMessageBatch>> messageRouterRawBatchClass,
+            Class<? extends MessageRouter<MessageGroupBatch>> messageRouterMessageGroupBatchClass,
+            Class<? extends MessageRouter<EventBatch>> eventBatchRouterClass,
+            Class<? extends GrpcRouter> grpcRouterClass) {
+        this(messageRouterParsedBatchClass, messageRouterRawBatchClass, messageRouterMessageGroupBatchClass, eventBatchRouterClass, grpcRouterClass,
                 CONFIG_DEFAULT_PATH.resolve(RABBIT_MQ_FILE_NAME),
                 CONFIG_DEFAULT_PATH.resolve(ROUTER_MQ_FILE_NAME),
                 CONFIG_DEFAULT_PATH.resolve(ROUTER_GRPC_FILE_NAME),

--- a/src/main/java/com/exactpro/th2/common/schema/message/configuration/QueueConfiguration.java
+++ b/src/main/java/com/exactpro/th2/common/schema/message/configuration/QueueConfiguration.java
@@ -22,37 +22,61 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.Getter;
-
-@Getter
 public class QueueConfiguration implements Configuration {
+    @JsonAlias("name")
+    @JsonProperty(required = true)
+    private String routingKey;
 
     /**
      * Routing key in RabbitMQ
      */
+    public String getRoutingKey() {
+        return routingKey;
+    }
+
     @JsonProperty(required = true)
-    private String name;
+    private String queue;
 
     /**
      * Queue name in RabbitMQ
      */
-    @JsonProperty(required = true)
-    private String queue;
+    public String getQueue() {
+        return queue;
+    }
 
     @JsonProperty(required = true)
     private String exchange;
 
-    @JsonAlias({"labels", "tags"})
+    public String getExchange() {
+        return exchange;
+    }
+
+    @JsonAlias({ "labels", "tags" })
     @JsonProperty(required = true)
     private List<String> attributes = Collections.emptyList();
+
+    public List<String> getAttributes() {
+        return attributes;
+    }
 
     @JsonProperty
     private List<MqRouterFilterConfiguration> filters = Collections.emptyList();
 
+    public List<MqRouterFilterConfiguration> getFilters() {
+        return filters;
+    }
+
     @JsonProperty(value = "read", defaultValue = "true")
     private boolean isReadable = true;
+
+    public boolean isReadable() {
+        return isReadable;
+    }
 
     @JsonProperty(value = "write", defaultValue = "true")
     private boolean isWritable = true;
 
+    public boolean isWritable() {
+        return isWritable;
+    }
 }

--- a/src/main/java/com/exactpro/th2/common/schema/message/impl/rabbitmq/AbstractRabbitBatchSubscriber.java
+++ b/src/main/java/com/exactpro/th2/common/schema/message/impl/rabbitmq/AbstractRabbitBatchSubscriber.java
@@ -16,18 +16,17 @@
 
 package com.exactpro.th2.common.schema.message.impl.rabbitmq;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.exactpro.th2.common.grpc.Direction;
 import com.exactpro.th2.common.schema.filter.strategy.FilterStrategy;
 import com.exactpro.th2.common.schema.filter.strategy.impl.DefaultFilterStrategy;
 import com.exactpro.th2.common.schema.message.configuration.RouterFilter;
 import com.google.protobuf.Message;
-import lombok.Builder;
-import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
 
 
 public abstract class AbstractRabbitBatchSubscriber<M extends Message, MB> extends AbstractRabbitSubscriber<MB> {
@@ -78,14 +77,34 @@ public abstract class AbstractRabbitBatchSubscriber<M extends Message, MB> exten
 
     protected abstract Metadata extractMetadata(M message);
 
-
-    @Getter
-    @Builder
     protected static class Metadata {
-        private long sequence;
-        private String messageType;
-        private String sessionAlias;
-        private Direction direction;
+        private final long sequence;
+        private final String messageType;
+        private final Direction direction;
+        private final String sessionAlias;
+
+        public Metadata(long sequence, String messageType, Direction direction, String sessionAlias) {
+            this.sequence = sequence;
+            this.messageType = messageType;
+            this.direction = direction;
+            this.sessionAlias = sessionAlias;
+        }
+
+        public long getSequence() {
+            return sequence;
+        }
+
+        public String getMessageType() {
+            return messageType;
+        }
+
+        public Direction getDirection() {
+            return direction;
+        }
+
+        public String getSessionAlias() {
+            return sessionAlias;
+        }
 
         @Override
         public String toString() {

--- a/src/main/java/com/exactpro/th2/common/schema/message/impl/rabbitmq/parsed/RabbitParsedBatchQueue.java
+++ b/src/main/java/com/exactpro/th2/common/schema/message/impl/rabbitmq/parsed/RabbitParsedBatchQueue.java
@@ -31,17 +31,14 @@ public class RabbitParsedBatchQueue extends AbstractRabbitQueue<MessageBatch> {
     @Override
     protected MessageSender<MessageBatch> createSender(@NotNull ConnectionManager connectionManager, @NotNull QueueConfiguration queueConfiguration) {
         MessageSender<MessageBatch> result = new RabbitParsedBatchSender();
-        result.init(connectionManager, queueConfiguration.getExchange(), queueConfiguration.getName());
+        result.init(connectionManager, queueConfiguration.getExchange(), queueConfiguration.getRoutingKey());
         return result;
     }
 
     @Override
     protected MessageSubscriber<MessageBatch> createSubscriber(@NotNull ConnectionManager connectionManager, @NotNull QueueConfiguration queueConfiguration) {
         MessageSubscriber<MessageBatch> result = new RabbitParsedBatchSubscriber(queueConfiguration.getFilters());
-        var subscribeTarget = SubscribeTarget.builder()
-                .routingKey(queueConfiguration.getName())
-                .queue(queueConfiguration.getQueue())
-                .build();
+        var subscribeTarget = new SubscribeTarget(queueConfiguration.getQueue(), queueConfiguration.getRoutingKey());
         result.init(connectionManager, queueConfiguration.getExchange(), subscribeTarget);
         return result;
     }

--- a/src/main/java/com/exactpro/th2/common/schema/message/impl/rabbitmq/parsed/RabbitParsedBatchSubscriber.java
+++ b/src/main/java/com/exactpro/th2/common/schema/message/impl/rabbitmq/parsed/RabbitParsedBatchSubscriber.java
@@ -16,14 +16,18 @@
 
 package com.exactpro.th2.common.schema.message.impl.rabbitmq.parsed;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.exactpro.th2.common.grpc.AnyMessage;
+import com.exactpro.th2.common.grpc.AnyMessage.KindCase;
 import com.exactpro.th2.common.grpc.Message;
 import com.exactpro.th2.common.grpc.MessageBatch;
+import com.exactpro.th2.common.grpc.MessageGroupBatch;
 import com.exactpro.th2.common.schema.filter.strategy.FilterStrategy;
+import com.exactpro.th2.common.schema.message.MessageRouterUtils;
 import com.exactpro.th2.common.schema.message.configuration.RouterFilter;
 import com.exactpro.th2.common.schema.message.impl.rabbitmq.AbstractRabbitBatchSubscriber;
-import com.google.protobuf.TextFormat;
-
-import java.util.List;
 
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
@@ -62,10 +66,27 @@ public class RabbitParsedBatchSubscriber extends AbstractRabbitBatchSubscriber<M
         super(filters, filterStrategy);
     }
 
-
     @Override
-    protected MessageBatch valueFromBytes(byte[] body) throws Exception {
-        return MessageBatch.parseFrom(body);
+    protected List<MessageBatch> valueFromBytes(byte[] body) throws Exception {
+        var groupBatch = MessageGroupBatch.parseFrom(body);
+        var messageGroups = groupBatch.getGroupsList();
+        var parsedBatches = new ArrayList<MessageBatch>(messageGroups.size());
+
+        for (var group : messageGroups) {
+            var builder = MessageBatch.newBuilder();
+
+            for (AnyMessage message : group.getMessagesList()) {
+                if (message.getKindCase() != KindCase.MESSAGE) {
+                    throw new IllegalStateException("Message group batch contains raw messages: " + MessageRouterUtils.toJson(groupBatch));
+                }
+
+                builder.addMessages(message.getMessage());
+            }
+
+            parsedBatches.add(builder.build());
+        }
+
+        return parsedBatches;
     }
 
     @Override
@@ -80,19 +101,19 @@ public class RabbitParsedBatchSubscriber extends AbstractRabbitBatchSubscriber<M
 
     @Override
     protected String toShortDebugString(MessageBatch value) {
-        return TextFormat.shortDebugString(value);
+        return MessageRouterUtils.toJson(value);
     }
 
     @Override
     protected Metadata extractMetadata(Message message) {
         var metadata = message.getMetadata();
         var messageID = metadata.getId();
-        return Metadata.builder()
-                .messageType(metadata.getMessageType())
-                .direction(messageID.getDirection())
-                .sequence(messageID.getSequence())
-                .sessionAlias(messageID.getConnectionId().getSessionAlias())
-                .build();
+        return new Metadata(
+                messageID.getSequence(),
+                metadata.getMessageType(),
+                messageID.getDirection(),
+                messageID.getConnectionId().getSessionAlias()
+        );
     }
 
 }

--- a/src/main/java/com/exactpro/th2/common/schema/message/impl/rabbitmq/raw/RabbitRawBatchQueue.java
+++ b/src/main/java/com/exactpro/th2/common/schema/message/impl/rabbitmq/raw/RabbitRawBatchQueue.java
@@ -31,17 +31,14 @@ public class RabbitRawBatchQueue extends AbstractRabbitQueue<RawMessageBatch> {
     @Override
     protected MessageSender<RawMessageBatch> createSender(@NotNull ConnectionManager connectionManager, @NotNull QueueConfiguration queueConfiguration) {
         var result = new RabbitRawBatchSender();
-        result.init(connectionManager, queueConfiguration.getExchange(), queueConfiguration.getName());
+        result.init(connectionManager, queueConfiguration.getExchange(), queueConfiguration.getRoutingKey());
         return result;
     }
 
     @Override
     protected MessageSubscriber<RawMessageBatch> createSubscriber(@NotNull ConnectionManager connectionManager, @NotNull QueueConfiguration queueConfiguration) {
         var result = new RabbitRawBatchSubscriber(queueConfiguration.getFilters());
-        var subscribeTarget = SubscribeTarget.builder()
-                .routingKey(queueConfiguration.getName())
-                .queue(queueConfiguration.getQueue())
-                .build();
+        var subscribeTarget = new SubscribeTarget(queueConfiguration.getQueue(), queueConfiguration.getRoutingKey());
         result.init(connectionManager, queueConfiguration.getExchange(), subscribeTarget);
         return result;
     }

--- a/src/main/java/com/exactpro/th2/common/schema/message/impl/rabbitmq/raw/RabbitRawBatchSubscriber.java
+++ b/src/main/java/com/exactpro/th2/common/schema/message/impl/rabbitmq/raw/RabbitRawBatchSubscriber.java
@@ -16,14 +16,18 @@
 
 package com.exactpro.th2.common.schema.message.impl.rabbitmq.raw;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.exactpro.th2.common.grpc.AnyMessage;
+import com.exactpro.th2.common.grpc.AnyMessage.KindCase;
+import com.exactpro.th2.common.grpc.MessageGroupBatch;
 import com.exactpro.th2.common.grpc.RawMessage;
 import com.exactpro.th2.common.grpc.RawMessageBatch;
 import com.exactpro.th2.common.schema.filter.strategy.FilterStrategy;
+import com.exactpro.th2.common.schema.message.MessageRouterUtils;
 import com.exactpro.th2.common.schema.message.configuration.RouterFilter;
 import com.exactpro.th2.common.schema.message.impl.rabbitmq.AbstractRabbitBatchSubscriber;
-import com.google.protobuf.TextFormat;
-
-import java.util.List;
 
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
@@ -65,8 +69,26 @@ public class RabbitRawBatchSubscriber extends AbstractRabbitBatchSubscriber<RawM
     }
 
     @Override
-    protected RawMessageBatch valueFromBytes(byte[] body) throws Exception {
-        return RawMessageBatch.parseFrom(body);
+    protected List<RawMessageBatch> valueFromBytes(byte[] body) throws Exception {
+        var groupBatch = MessageGroupBatch.parseFrom(body);
+        var messageGroups = groupBatch.getGroupsList();
+        var rawBatches = new ArrayList<RawMessageBatch>(messageGroups.size());
+
+        for (var group : messageGroups) {
+            var builder = RawMessageBatch.newBuilder();
+
+            for (AnyMessage message : group.getMessagesList()) {
+                if (message.getKindCase() != KindCase.RAW_MESSAGE) {
+                    throw new IllegalStateException("Message group batch contains parsed messages: " + MessageRouterUtils.toJson(groupBatch));
+                }
+
+                builder.addMessages(message.getRawMessage());
+            }
+
+            rawBatches.add(builder.build());
+        }
+
+        return rawBatches;
     }
 
     @Override
@@ -81,19 +103,19 @@ public class RabbitRawBatchSubscriber extends AbstractRabbitBatchSubscriber<RawM
 
     @Override
     protected String toShortDebugString(RawMessageBatch value) {
-        return TextFormat.shortDebugString(value);
+        return MessageRouterUtils.toJson(value);
     }
 
     @Override
     protected Metadata extractMetadata(RawMessage message) {
         var metadata = message.getMetadata();
         var messageID = metadata.getId();
-        return Metadata.builder()
-                .messageType(MESSAGE_TYPE)
-                .direction(messageID.getDirection())
-                .sequence(messageID.getSequence())
-                .sessionAlias(messageID.getConnectionId().getSessionAlias())
-                .build();
+        return new Metadata(
+                messageID.getSequence(),
+                MESSAGE_TYPE,
+                messageID.getDirection(),
+                messageID.getConnectionId().getSessionAlias()
+        );
     }
 
 }

--- a/src/main/kotlin/com/exactpro/th2/common/message/MessageUtils.kt
+++ b/src/main/kotlin/com/exactpro/th2/common/message/MessageUtils.kt
@@ -16,6 +16,15 @@
 
 package com.exactpro.th2.common.message
 
+import com.exactpro.th2.common.grpc.AnyMessage
+import com.exactpro.th2.common.grpc.ConnectionID
+import com.exactpro.th2.common.grpc.Direction
+import com.exactpro.th2.common.grpc.Message
+import com.exactpro.th2.common.grpc.MessageGroup
+import com.exactpro.th2.common.grpc.MessageID
+import com.exactpro.th2.common.grpc.MessageMetadata
+import com.exactpro.th2.common.grpc.RawMessage
+import com.exactpro.th2.common.grpc.Value
 import com.exactpro.th2.common.value.getBigDecimal
 import com.exactpro.th2.common.value.getBigInteger
 import com.exactpro.th2.common.value.getDouble
@@ -25,12 +34,6 @@ import com.exactpro.th2.common.value.getMessage
 import com.exactpro.th2.common.value.getString
 import com.exactpro.th2.common.value.nullValue
 import com.exactpro.th2.common.value.toValue
-import com.exactpro.th2.common.grpc.ConnectionID
-import com.exactpro.th2.common.grpc.Direction
-import com.exactpro.th2.common.grpc.Message
-import com.exactpro.th2.common.grpc.MessageID
-import com.exactpro.th2.common.grpc.MessageMetadata
-import com.exactpro.th2.common.grpc.Value
 import com.google.protobuf.Timestamp
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -110,6 +113,22 @@ fun Message.Builder.setMetadata(messageType: String? = null, direction: Directio
             }.build()
         }
     })
+
+operator fun MessageGroup.Builder.plusAssign(message: Message) {
+    addMessages(AnyMessage.newBuilder().setMessage(message))
+}
+
+operator fun MessageGroup.Builder.plusAssign(message: Message.Builder) {
+    addMessages(AnyMessage.newBuilder().setMessage(message))
+}
+
+operator fun MessageGroup.Builder.plusAssign(rawMessage: RawMessage) {
+    addMessages(AnyMessage.newBuilder().setRawMessage(rawMessage))
+}
+
+operator fun MessageGroup.Builder.plusAssign(rawMessage: RawMessage.Builder) {
+    addMessages(AnyMessage.newBuilder().setRawMessage(rawMessage))
+}
 
 fun Instant.toTimestamp(): Timestamp = Timestamp.newBuilder().setSeconds(epochSecond).setNanos(nano).build()
 fun Date.toTimestamp(): Timestamp = toInstant().toTimestamp()

--- a/src/main/kotlin/com/exactpro/th2/common/schema/message/MessageRouterUtils.kt
+++ b/src/main/kotlin/com/exactpro/th2/common/schema/message/MessageRouterUtils.kt
@@ -25,6 +25,8 @@ import com.exactpro.th2.common.event.EventUtils
 import com.exactpro.th2.common.grpc.EventBatch
 import com.exactpro.th2.common.schema.message.QueueAttribute.EVENT
 import com.exactpro.th2.common.schema.message.QueueAttribute.PUBLISH
+import com.google.protobuf.MessageOrBuilder
+import com.google.protobuf.util.JsonFormat
 
 fun MessageRouter<EventBatch>.storeEvent(
     event: Event,
@@ -54,3 +56,8 @@ fun MessageRouter<EventBatch>.storeEvent(
 
     storeEvent(this, parentId)
 }
+
+fun MessageOrBuilder.toJson(): String = JsonFormat.printer()
+    .omittingInsignificantWhitespace()
+    .includingDefaultValueFields()
+    .print(this)

--- a/src/main/kotlin/com/exactpro/th2/common/schema/message/impl/rabbitmq/configuration/SubscribeTarget.kt
+++ b/src/main/kotlin/com/exactpro/th2/common/schema/message/impl/rabbitmq/configuration/SubscribeTarget.kt
@@ -14,21 +14,6 @@
  * limitations under the License.
  */
 
-package com.exactpro.th2.common.schema.message.impl.rabbitmq.configuration;
+package com.exactpro.th2.common.schema.message.impl.rabbitmq.configuration
 
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
-
-@Getter
-@Builder
-@ToString
-@EqualsAndHashCode
-public class SubscribeTarget {
-
-    private String queue;
-
-    private String routingKey;
-
-}
+data class SubscribeTarget(val queue: String, val routingKey: String)

--- a/src/main/kotlin/com/exactpro/th2/common/schema/message/impl/rabbitmq/group/RabbitMessageGroupBatchQueue.kt
+++ b/src/main/kotlin/com/exactpro/th2/common/schema/message/impl/rabbitmq/group/RabbitMessageGroupBatchQueue.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020-2020 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.common.schema.message.impl.rabbitmq.group
+
+import com.exactpro.th2.common.grpc.MessageGroupBatch
+import com.exactpro.th2.common.schema.message.MessageSender
+import com.exactpro.th2.common.schema.message.MessageSubscriber
+import com.exactpro.th2.common.schema.message.configuration.QueueConfiguration
+import com.exactpro.th2.common.schema.message.impl.rabbitmq.AbstractRabbitQueue
+import com.exactpro.th2.common.schema.message.impl.rabbitmq.configuration.SubscribeTarget
+import com.exactpro.th2.common.schema.message.impl.rabbitmq.connection.ConnectionManager
+
+class RabbitMessageGroupBatchQueue : AbstractRabbitQueue<MessageGroupBatch>() {
+    override fun createSender(connectionManager: ConnectionManager, queueConfiguration: QueueConfiguration): MessageSender<MessageGroupBatch> {
+        return RabbitMessageGroupBatchSender().apply {
+            init(connectionManager, queueConfiguration.exchange, queueConfiguration.routingKey)
+        }
+    }
+
+    override fun createSubscriber(connectionManager: ConnectionManager, queueConfiguration: QueueConfiguration): MessageSubscriber<MessageGroupBatch> {
+        return RabbitMessageGroupBatchSubscriber(queueConfiguration.filters).apply {
+            val target = SubscribeTarget(queueConfiguration.queue, queueConfiguration.routingKey)
+            init(connectionManager, queueConfiguration.exchange, target)
+        }
+    }
+}

--- a/src/main/kotlin/com/exactpro/th2/common/schema/message/impl/rabbitmq/group/RabbitMessageGroupBatchRouter.kt
+++ b/src/main/kotlin/com/exactpro/th2/common/schema/message/impl/rabbitmq/group/RabbitMessageGroupBatchRouter.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020-2020 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.common.schema.message.impl.rabbitmq.group
+
+import com.exactpro.th2.common.grpc.MessageGroup
+import com.exactpro.th2.common.grpc.MessageGroupBatch
+import com.exactpro.th2.common.grpc.MessageGroupBatch.Builder
+import com.exactpro.th2.common.schema.message.MessageQueue
+import com.exactpro.th2.common.schema.message.QueueAttribute.PUBLISH
+import com.exactpro.th2.common.schema.message.QueueAttribute.SUBSCRIBE
+import com.exactpro.th2.common.schema.message.configuration.QueueConfiguration
+import com.exactpro.th2.common.schema.message.impl.rabbitmq.connection.ConnectionManager
+import com.exactpro.th2.common.schema.message.impl.rabbitmq.router.AbstractRabbitBatchMessageRouter
+
+class RabbitMessageGroupBatchRouter : AbstractRabbitBatchMessageRouter<MessageGroup, MessageGroupBatch, MessageGroupBatch.Builder>() {
+    override fun createQueue(connectionManager: ConnectionManager, queueConfiguration: QueueConfiguration): MessageQueue<MessageGroupBatch> {
+        return RabbitMessageGroupBatchQueue().apply {
+            init(connectionManager, queueConfiguration)
+        }
+    }
+
+    override fun requiredSubscribeAttributes(): Set<String> = REQUIRED_SUBSCRIBE_ATTRIBUTES
+
+    override fun requiredSendAttributes(): Set<String> = REQUIRED_SEND_ATTRIBUTES
+
+    override fun getMessages(batch: MessageGroupBatch): MutableList<MessageGroup> = batch.groupsList
+
+    override fun createBatchBuilder(): Builder = MessageGroupBatch.newBuilder()
+
+    override fun addMessage(builder: Builder, group: MessageGroup) {
+        builder.addGroups(group)
+    }
+
+    override fun build(builder: Builder): MessageGroupBatch = builder.build()
+
+    companion object {
+        private val REQUIRED_SUBSCRIBE_ATTRIBUTES = setOf(SUBSCRIBE.toString())
+        private val REQUIRED_SEND_ATTRIBUTES = setOf(PUBLISH.toString())
+    }
+}

--- a/src/main/kotlin/com/exactpro/th2/common/schema/message/impl/rabbitmq/group/RabbitMessageGroupBatchSender.kt
+++ b/src/main/kotlin/com/exactpro/th2/common/schema/message/impl/rabbitmq/group/RabbitMessageGroupBatchSender.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020-2020 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.common.schema.message.impl.rabbitmq.group
+
+import com.exactpro.th2.common.grpc.MessageGroupBatch
+import com.exactpro.th2.common.schema.message.impl.rabbitmq.AbstractRabbitSender
+import com.exactpro.th2.common.schema.message.toJson
+import io.prometheus.client.Counter
+
+class RabbitMessageGroupBatchSender : AbstractRabbitSender<MessageGroupBatch>() {
+    override fun getDeliveryCounter(): Counter = OUTGOING_MSG_GROUP_BATCH_QUANTITY
+    override fun getContentCounter(): Counter = OUTGOING_MSG_GROUP_QUANTITY
+    override fun extractCountFrom(message: MessageGroupBatch): Int = message.groupsCount
+    override fun valueToBytes(value: MessageGroupBatch): ByteArray = value.toByteArray()
+    override fun toShortDebugString(value: MessageGroupBatch): String = value.toJson()
+
+    companion object {
+        private val OUTGOING_MSG_GROUP_BATCH_QUANTITY = Counter.build("th2_mq_outgoing_msg_group_batch_quantity", "Quantity of outgoing message group batches").register()
+        private val OUTGOING_MSG_GROUP_QUANTITY = Counter.build("th2_mq_outgoing_msg_group_quantity", "Quantity of outgoing message groups").register()
+    }
+}

--- a/src/main/kotlin/com/exactpro/th2/common/schema/message/impl/rabbitmq/group/RabbitMessageGroupBatchSubscriber.kt
+++ b/src/main/kotlin/com/exactpro/th2/common/schema/message/impl/rabbitmq/group/RabbitMessageGroupBatchSubscriber.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020-2020 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.common.schema.message.impl.rabbitmq.group
+
+import com.exactpro.th2.common.grpc.AnyMessage
+import com.exactpro.th2.common.grpc.AnyMessage.KindCase.MESSAGE
+import com.exactpro.th2.common.grpc.AnyMessage.KindCase.RAW_MESSAGE
+import com.exactpro.th2.common.grpc.MessageGroup
+import com.exactpro.th2.common.grpc.MessageGroupBatch
+import com.exactpro.th2.common.schema.filter.strategy.FilterStrategy
+import com.exactpro.th2.common.schema.filter.strategy.impl.DefaultFilterStrategy
+import com.exactpro.th2.common.schema.message.configuration.RouterFilter
+import com.exactpro.th2.common.schema.message.impl.rabbitmq.AbstractRabbitBatchSubscriber
+import com.exactpro.th2.common.schema.message.toJson
+import io.prometheus.client.Counter
+import io.prometheus.client.Gauge
+import mu.KotlinLogging
+
+class RabbitMessageGroupBatchSubscriber(
+    private val filters: List<RouterFilter>,
+    private val filterStrategy: FilterStrategy = DefaultFilterStrategy()
+) : AbstractRabbitBatchSubscriber<MessageGroup, MessageGroupBatch>(filters, filterStrategy) {
+    private val logger = KotlinLogging.logger {}
+
+    override fun getDeliveryCounter(): Counter = INCOMING_MSG_GROUP_BATCH_QUANTITY
+    override fun getContentCounter(): Counter = INCOMING_MSG_GROUP_QUANTITY
+    override fun getProcessingTimer(): Gauge = MSG_GROUP_PROCESSING_TIME
+    override fun extractCountFrom(message: MessageGroupBatch): Int = message.groupsCount
+    override fun valueFromBytes(body: ByteArray): List<MessageGroupBatch> = listOf(MessageGroupBatch.parseFrom(body))
+    override fun getMessages(batch: MessageGroupBatch): MutableList<MessageGroup> = batch.groupsList
+    override fun createBatch(messages: List<MessageGroup>): MessageGroupBatch = MessageGroupBatch.newBuilder().addAllGroups(messages).build()
+    override fun toShortDebugString(value: MessageGroupBatch): String = value.toJson()
+
+    override fun extractMetadata(messageGroup: MessageGroup): Metadata = throw UnsupportedOperationException()
+
+    private fun extractMetadata(message: AnyMessage): Metadata {
+        val (messageType, messageId) = when (val kindCase = message.kindCase) {
+            MESSAGE -> message.message.metadata.run { messageType to id }
+            RAW_MESSAGE -> message.rawMessage.metadata.run { RAW_MESSAGE_TYPE to id }
+            else -> error("Unsupported group message kind: $kindCase")
+        }
+
+        return Metadata(
+            messageId.sequence,
+            messageType,
+            messageId.direction,
+            messageId.connectionId.sessionAlias
+        )
+    }
+
+    override fun filter(batch: MessageGroupBatch): MessageGroupBatch? {
+        if (filters.isEmpty()) {
+            return batch
+        }
+
+        val groups = getMessages(batch).asSequence()
+            .map { group ->
+                group.messagesList.filter { message ->
+                    if (!filterStrategy.verify(message, filters)) {
+                        logger.debug { "Skipped message because it didn't match any filters: ${extractMetadata(message)}" }
+                        return@filter false
+                    }
+
+                    true
+                }
+            }
+            .filter { it.isNotEmpty() }
+            .map { MessageGroup.newBuilder().addAllMessages(it).build() }
+            .toList()
+
+        return if (groups.isEmpty()) null else createBatch(groups)
+    }
+
+    companion object {
+        private const val RAW_MESSAGE_TYPE = "raw"
+        private val INCOMING_MSG_GROUP_BATCH_QUANTITY = Counter.build("th2_mq_incoming_msg_group_batch_quantity", "Quantity of incoming message group batches").register()
+        private val INCOMING_MSG_GROUP_QUANTITY = Counter.build("th2_mq_incoming_msg_group_quantity", "Quantity of incoming message groups").register()
+        private val MSG_GROUP_PROCESSING_TIME = Gauge.build("th2_mq_msg_group_processing_time", "Time of processing message groups").register()
+    }
+}

--- a/src/main/kotlin/com/exactpro/th2/common/value/ValueUtils.kt
+++ b/src/main/kotlin/com/exactpro/th2/common/value/ValueUtils.kt
@@ -20,7 +20,6 @@ import com.exactpro.th2.common.grpc.ListValue
 import com.exactpro.th2.common.grpc.Message
 import com.exactpro.th2.common.grpc.NullValue.NULL_VALUE
 import com.exactpro.th2.common.grpc.Value
-import com.exactpro.th2.common.grpc.Value.KindCase.LIST_VALUE
 import com.exactpro.th2.common.grpc.Value.KindCase.MESSAGE_VALUE
 import com.exactpro.th2.common.grpc.Value.KindCase.SIMPLE_VALUE
 import java.math.BigDecimal
@@ -62,6 +61,7 @@ fun Any.toValue(): Value = when (this) {
     is LongArray -> toValue()
     is FloatArray -> toValue()
     is DoubleArray -> toValue()
+    is Value -> this
     else -> toString().toValue()
 }
 


### PR DESCRIPTION
 * make parsed and raw message routers use message group batches under the hood
 * remove some usages of Lombok's annotations because it makes annotated classes harder to use from Kotlin code