### PR TITLE
[th2-2789] ignore unknown fields in box.json and prometheus.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# th2 common library (Java) (3.31.3)
+# th2 common library (Java) (3.31.4)
 
 ## Usage
 
@@ -287,6 +287,10 @@ dependencies {
 ```
 
 ## Release notes
+
+### 3.31.4
+
++ Ignore unknown fields in `box.json` and `prometheus.json`
 
 ### 3.31.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-release_version=3.31.3
+release_version=3.31.4
 
 description = 'th2 common library (Java)'
 

--- a/src/main/java/com/exactpro/th2/common/schema/box/configuration/BoxConfiguration.java
+++ b/src/main/java/com/exactpro/th2/common/schema/box/configuration/BoxConfiguration.java
@@ -15,11 +15,12 @@
 
 package com.exactpro.th2.common.schema.box.configuration;
 
+import com.exactpro.th2.common.schema.configuration.Configuration;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.jetbrains.annotations.Nullable;
 
-public class BoxConfiguration {
-
+public class BoxConfiguration extends Configuration {
     @JsonProperty
     private String boxName = null;
 

--- a/src/main/kotlin/com/exactpro/th2/common/metrics/PrometheusConfiguration.kt
+++ b/src/main/kotlin/com/exactpro/th2/common/metrics/PrometheusConfiguration.kt
@@ -16,4 +16,10 @@
 
 package com.exactpro.th2.common.metrics
 
-data class PrometheusConfiguration(val host: String = "0.0.0.0", val port: Int = 9752, val enabled: Boolean = true)
+import com.exactpro.th2.common.schema.configuration.Configuration
+
+data class PrometheusConfiguration(
+    val host: String = "0.0.0.0",
+    val port: Int = 9752,
+    val enabled: Boolean = true,
+) : Configuration()


### PR DESCRIPTION
Other configurations extends `com.exactpro.th2.common.schema.configuration.Configuration` already where we have warning in case some field is unknown:
```
@JsonAnySetter
fun setField(name: String, value: Any?) {
    logger.warn("Ignore unknown field with name '{}' in configuration class '{}'", name, this::class.java.name)
}
```