### PR TITLE
[th2-3019] Fix: shutdown underlying EventLoopGroup and ExecutorService

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# th2 common library (Java) (3.32.0)
+# th2 common library (Java) (3.32.1)
 
 ## Usage
 
@@ -288,10 +288,13 @@ dependencies {
 
 ## Release notes
 
+### 3.32.1
+
++ Fixed: gRPC router didn't shut down underlying Netty's EventLoopGroup and ExecutorService 
+
 ### 3.32.0
 
 + Added new test utils for assertion of **AnyMessage** or **Groups** of messages
-
 
 ### 3.31.6
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-release_version=3.32.0
+release_version=3.32.1
 
 description = 'th2 common library (Java)'
 

--- a/src/main/java/com/exactpro/th2/common/schema/grpc/router/AbstractGrpcRouter.java
+++ b/src/main/java/com/exactpro/th2/common/schema/grpc/router/AbstractGrpcRouter.java
@@ -135,8 +135,7 @@ public abstract class AbstractGrpcRouter implements GrpcRouter {
         loopGroups.forEach(EventExecutorGroup::shutdownGracefully);
         loopGroups.forEach(group -> {
             if (!group.terminationFuture().awaitUninterruptibly(SERVER_SHUTDOWN_TIMEOUT_MS)) {
-                LOGGER.warn("Failed to shutdown event loop '{}' in {} ms. Forcing shutdown...", group, SERVER_SHUTDOWN_TIMEOUT_MS);
-                group.shutdownNow();
+                LOGGER.error("Failed to shutdown event loop '{}' in {} ms.", group, SERVER_SHUTDOWN_TIMEOUT_MS);
             }
         });
 


### PR DESCRIPTION
According to NettyServerBuilder docs: “The server won't take ownership of the given EventLoopGroup. It's caller's responsibility to shut it down when it's desired”. ExecutorService used to create EventLoopGroup also should be shut down.