### PR TITLE
MessageRouterUtils > MessageGroupBatch.toShortDebugString() > Do not coalesce identical message-IDs

### DIFF
--- a/src/main/kotlin/com/exactpro/th2/common/schema/message/MessageRouterUtils.kt
+++ b/src/main/kotlin/com/exactpro/th2/common/schema/message/MessageRouterUtils.kt
@@ -82,8 +82,7 @@ fun MessageGroupBatch.toShortDebugString(): String = buildString {
     groupsList.asSequence()
         .flatMap { it.messagesList.asSequence() }
         .map(AnyMessage::logId)
-        .toSortedSet()
-        .apply { append(this) }
+        .joinTo(this, prefix = "[", postfix = "]")
 
     append(')')
 }


### PR DESCRIPTION
This could help to avoid confusion during debugging when a batch/group of messages with identical IDs is received and we're checking message count or for duplicate message IDs e.g.: 
I've had a case where I received message group with 2 messages with the same ID, message router log would show that the there's only 1 message in group but my "group message count == 1" check would fail and I couldn't understand why.


